### PR TITLE
Add configuration for password recovery token

### DIFF
--- a/src/config.php.dist
+++ b/src/config.php.dist
@@ -106,6 +106,12 @@ $config = array(
     // Input directory for locale strings
     //'engine.text.i18n.source' => './resource/language',
 
+    // Hash algo used for password recovery token
+    // 'engine.entity.account.tokenhash' => 'crc32b',
+
+    // Password recovery token length
+    // 'engine.entity.account.tokenlen' => 8,
+
     // Configuration file version
     //'version' => 1
 );

--- a/src/entity/account/user.php
+++ b/src/entity/account/user.php
@@ -228,7 +228,10 @@ class User extends \yN\Entity\Model
             return null;
         }
 
-        return substr(hash_hmac('crc32b', $this->recover_time, $this->id), 0, 8);
+        $token_hash = config('engine.entity.account.tokenhash', 'crc32b');
+        $token_length = config('engine.entity.account.tokenlen', 8);
+
+        return substr(hash_hmac($token_hash, $this->recover_time, $this->id), 0, $token_length);
     }
 
     public function get_template($external)


### PR DESCRIPTION
Add two configuration option:
- one for hash algo used
- one for token len

Reason: PHP 7.2 removed crc32b so needed to have a way to easily change the hash algorithm used.
