### PR TITLE
[resource.template] Fix container ID generation in forms.

### DIFF
--- a/src/resource/template/fragment/control-form.deval
+++ b/src/resource/template/fragment/control-form.deval
@@ -1,4 +1,4 @@
-{{ let id = php ("uniqid") () }}
+{{ let id = ((-)(php ("uniqid"))) () }}
 	<div class="container" id="{{ $ id }}">
 		{{ if length (_alerts) > 0 }}
 			<div class="notice notice-fail">


### PR DESCRIPTION
ID was generated at compile time rather than run time, resulting in a single
random ID being used for all form containers and therefore breaking some JS
integrations (markItUp, autofocus, autocomplete & drafts).