### PR TITLE
Fixes for docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       APACHE_PID_FILE: /var/run/apache2/apache2.pid
       APACHE_RUN_DIR: /var/run/apache2
       APACHE_LOCK_DIR: /var/lock/apache2
-      APACHE_LOG_DIR: /var/log/apache2
     ports:
       - "8000:80"
     links:

--- a/setup/docker/Dockerfile
+++ b/setup/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
         libmcrypt-dev \
         gnupg \
         locales \
+        rsync \
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     && apt-get install -y \
         nodejs \


### PR DESCRIPTION
- Rync missing in the image 
- remove duplicate of the APACHE_LOG_DIR environment variable